### PR TITLE
Add non-regression tests, prune beam search

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,8 @@ You can also run it for `beam_width=1, 2, 4, 8, ..., 2^power`:
 >>> for moves in anytime_beam_search(board, power=5):
 ...    print(f"Found solution of length {len(moves)}: {moves}")
 Found solution of length 7: [(0, 0), (2, 1), (1, 0), (1, 2), (2, 0), (2, 1), (2, 2)]
-Found solution of length 6: [(0, 0), (2, 0), (2, 0), (2, 1), (2, 2), (2, 2)]
-Found solution of length 5: [(2, 0), (2, 0), (2, 1), (2, 0), (2, 2)]
+Found solution of length 6: [(0, 0), (1, 2), (1, 2), (2, 0), (2, 1), (2, 0)]
+Found solution of length 5: [(0, 0), (2, 0), (1, 2), (1, 2), (2, 1)]
 Found solution of length 4: [(2, 0), (1, 1), (1, 0), (1, 2)]
-
 
 ```

--- a/solvers.py
+++ b/solvers.py
@@ -480,7 +480,7 @@ class BeamNode:
         return hash(self.board)
 
 
-def beam_search(board: Board, *, beam_width: int = 3) -> list:
+def beam_search(board: Board, *, beam_width: int = 3, shortest_path=None) -> list:
     """Beam search with specified beam width.
 
     Maintains only the top beam_width nodes at each depth level.
@@ -520,6 +520,14 @@ def beam_search(board: Board, *, beam_width: int = 3) -> list:
         # Only keep unique boards. If two boards are unique we know the path
         # length must be unique too, so we can discard the duplicates
         next_beam = unique_everseen(next_beam)
+
+        # Only keep boards where we can do better
+        if shortest_path:
+            next_beam = (
+                node
+                for node in next_beam
+                if len(node.moves) + estimate_remaining(node.board) < shortest_path
+            )
 
         # Keep only the best beam_width nodes
         beam = nlargest(n=beam_width, iterable=next_beam)
@@ -568,7 +576,7 @@ def anytime_beam_search(board, *, power: int = 1, verbose: bool = False):
         if verbose:
             print(f"Beam search with beam_width=2**{p}={2**p}")
 
-        moves = beam_search(board, beam_width=2**p)
+        moves = beam_search(board, beam_width=2**p, shortest_path=shortest_path)
 
         # Only yield if we found a better solution
         if moves and len(moves) < shortest_path:

--- a/test_solvers.py
+++ b/test_solvers.py
@@ -4,6 +4,7 @@ Tests for solvers.
 
 import pytest
 import random
+import statistics
 
 
 from board import Board, LabelInvariantBoard
@@ -37,8 +38,8 @@ class TestSolvers:
         assert board.verify_solution(moves_bfs)
         assert board.verify_solution(moves_ids)
 
-        # Verify that A* is as good as BFS, which is more naive
-        assert len(moves_bfs) == len(moves_ids)
+        # Verify that IDS is as good as BFS, which is more naive
+        assert len(moves_ids) == len(moves_bfs)
 
     @pytest.mark.parametrize("seed", range(25))
     @pytest.mark.parametrize("relabel", [True, False])
@@ -117,6 +118,38 @@ class TestSolvers:
                 break
         else:
             assert False
+
+
+class TestNonRegressionOnPerformance:
+    def test_performance_anytime_beam_search(self):
+        solution_lengths = []
+        for seed in range(10):
+            board = Board.generate_random(shape=(9, 7), seed=seed)
+            *_, moves = anytime_beam_search(board, power=5)
+            assert board.verify_solution(moves)
+            solution_lengths.append(len(moves))
+
+        assert statistics.mean(solution_lengths) <= 16.8
+
+    def test_performance_heuristic_search(self):
+        solution_lengths = []
+        for seed in range(10):
+            board = Board.generate_random(shape=(9, 7), seed=seed)
+            *_, moves = heuristic_search(board, max_nodes=5000)
+            assert board.verify_solution(moves)
+            solution_lengths.append(len(moves))
+
+        assert statistics.mean(solution_lengths) <= 18.6
+
+    def test_performance_verify_solution(self):
+        solution_lengths = []
+        for seed in range(10):
+            board = Board.generate_random(shape=(9, 7), seed=seed)
+            *_, moves = monte_carlo_search(board, iterations=100, seed=seed)
+            assert board.verify_solution(moves)
+            solution_lengths.append(len(moves))
+
+        assert statistics.mean(solution_lengths) <= 18.4
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Before**
```
Benchmarking: anytime_beam_search(board, {'power': 10})
 ..........
 Solutions of avg. length 15.500 in 17.326 sec.
 Avg. length times sec (lower is better) => 268.549
```

**After**
```
Benchmarking: anytime_beam_search(board, {'power': 10})
 ..........
 Solutions of avg. length 15.000 in 16.844 sec.
 Avg. length times sec (lower is better) => 252.663
```