### PR TITLE
Tune default key function, replace heuristic_search with branch and bound

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,9 +226,8 @@ In the long run it produces a solution, but again we might run out of memory.
 ...    print(f"Found solution of length {len(moves)}")
 Found solution of length 24
 Found solution of length 23
-Found solution of length 22
-Found solution of length 21
 Found solution of length 20
+Found solution of length 19
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -70,85 +70,178 @@ All children (results of all valid clicks) can be retrieved:
 
 ## The solvers
 
-**Best first search** chooses the move that clears the most cells.
-There are no guarantees that this results in an optimal solution.
+Let us try to solve the NRK board for November 25th 2024 with a few solvers:
 
 ```pycon
->>> from solvers import best_first_search
->>> board = Board([[4, 3, 3, 1, 1], 
-...                [1, 4, 4, 3, 2], 
-...                [3, 2, 4, 4, 3], 
-...                [3, 1, 4, 1, 4], 
-...                [4, 1, 2, 4, 3]])
->>> moves = best_first_search(board)
->>> moves
-[(3, 3), (1, 4), (1, 3), (1, 1), (3, 1), (4, 1), (1, 0), (2, 0), (3, 4), (3, 0)]
->>> board.verify_solution(moves)
-True
+>>> board = Board([[1, 2, 1, 2, 1, 3, 3], 
+...                [2, 1, 2, 3, 4, 2, 1], 
+...                [4, 2, 1, 2, 1, 1, 3], 
+...                [2, 4, 2, 2, 1, 2, 1], 
+...                [3, 1, 4, 2, 2, 1, 1], 
+...                [1, 1, 3, 4, 3, 2, 2], 
+...                [3, 3, 3, 2, 3, 3, 1], 
+...                [3, 1, 2, 1, 3, 2, 2], 
+...                [3, 3, 1, 2, 2, 1, 4]])
 
 ```
 
-**A\* search with an admissible heuristic** is guaranteed to solve the problem,
-but with large boards we run out of memory and the compute time is too long.
-A better heuristic could help---make a PR if you have an idea!
+### Greedy search
+
+**Greedy search** chooses the best move at each level.
+The _best move_ is defined by a key function that takes a node as input and returns a number.
+The lower the number, the better the move.
+
+Greedy search is quite flexible!
+A first heuristic we can try is to maximize cells cleared per move.
 
 ```pycon
->>> from solvers import a_star_search
->>> moves = a_star_search(board)
->>> moves
-[(2, 0), (3, 0), (4, 1), (0, 3), (3, 3), (2, 2), (3, 4), (4, 4)]
->>> board.verify_solution(moves)
-True
+>>> from solvers import greedy_search
+>>> def cleared_per_move(node):
+...     # We flip the sign because lower is better
+...     return -node.cleared / len(node.moves)
+>>> len(greedy_search(board, key=cleared_per_move))
+27
 
 ```
+
+The heuristic above looks at _what has worked so far_.
+We get better results if we look at _what will happen in the future_:
+
+```pycon
+>>> def average(node):
+...     return (node.board.lower_bound + node.board.upper_bound) / 2
+>>> len(greedy_search(board, key=average))
+17
+
+```
+
+A range on lower and upper bound like `[8, 12]` is probably better than `[6, 14]`
+even though the average is the same.
+We can break ties by adding more scores and returning a tuple:
+
+```pycon
+>>> def modified_average(node):
+...     avg = (node.board.lower_bound + node.board.upper_bound) / 2
+...     range_ = node.board.upper_bound - node.board.lower_bound
+...     cleared_per_move = node.cleared / len(node.moves)
+...     return (avg, range_, -cleared_per_move)
+>>> len(greedy_search(board, key=modified_average))
+16
+
+```
+
+Randomized search can also be expressed with a key function:
+
+```pycon
+>>> import random
+>>> rng = random.Random(0)
+>>> def random_key(node):
+...     return rng.random()
+>>> len(greedy_search(board, key=random_key))
+30
+
+```
+
+### Heuristic search
 
 **Heuristic search** uses a priority queue and yields solutions as they are discovered.
-If you let it run long enough, it will produce an optimal solution.
-You might run out of memory before that happens though.
+If we let it run long enough, it will produce an optimal solution.
+We might run out of memory before that happens though.
 
 ```pycon
 >>> from solvers import heuristic_search
->>> for moves in heuristic_search(board):
-...    print(f"Found solution of length {len(moves)}: {moves}")
-Found solution of length 10: [(3, 3), (1, 4), (1, 3), (1, 1), (3, 1), (4, 1), (1, 0), (2, 0), (3, 4), (3, 0)]
-Found solution of length 9: [(3, 3), (1, 4), (1, 3), (1, 1), (2, 0), (3, 0), (4, 1), (3, 4), (3, 0)]
-Found solution of length 8: [(3, 3), (1, 4), (1, 3), (2, 0), (3, 0), (1, 2), (4, 1), (3, 4)]
+>>> for moves in heuristic_search(board, key=cleared_per_move, iterations=999):
+...    print(f"Found solution of length {len(moves)}")
+...    assert board.verify_solution(moves)
+Found solution of length 27
+Found solution of length 22
+Found solution of length 20
+Found solution of length 18
 
 ```
 
-**Monte Carlo tree search** also yields solutions as they are discovered.
-In the long run it produces a solution, but again you might run out of memory.
+Better key functions give better results faster:
 
 ```pycon
->>> from solvers import monte_carlo_search
->>> for moves in monte_carlo_search(board, seed=1):
-...    print(f"Found solution of length {len(moves)}: {moves}")
-Found solution of length 10: [(3, 3), (1, 4), (1, 3), (1, 1), (3, 1), (4, 1), (1, 0), (2, 0), (3, 4), (3, 0)]
-Found solution of length 9: [(1, 4), (3, 3), (2, 0), (3, 0), (1, 2), (4, 1), (3, 3), (2, 4), (3, 4)]
-Found solution of length 8: [(0, 3), (3, 3), (2, 0), (3, 0), (1, 2), (4, 1), (3, 4), (4, 4)]
+>>> for moves in heuristic_search(board, key=modified_average, iterations=999):
+...    print(f"Found solution of length {len(moves)}")
+Found solution of length 16
 
 ```
+
+The solver can be given an initial solution via the `moves` argument.
+The default `key=None` uses a good key.
+
+```pycon
+
+>>> moves = greedy_search(board)
+>>> len(moves)
+19
+>>> for moves in heuristic_search(board, iterations=9999, moves=moves):
+...    print(f"Found solution of length {len(moves)}")
+...    assert board.verify_solution(moves)
+Found solution of length 15
+Found solution of length 14
+Found solution of length 13
+
+```
+
+### Beam search
 
 **Beam search** expands all children, keeps the `beam_width` best nodes, 
 expands all children of those nodes, and repeats.
 
 ```pycon
 >>> from solvers import beam_search
->>> len(beam_search(board, beam_width=2))
-9
->>> len(beam_search(board, beam_width=4))
-8
+>>> len(beam_search(board, beam_width=1, key=modified_average))
+16
+>>> len(beam_search(board, beam_width=2, key=modified_average))
+15
+>>> len(beam_search(board, beam_width=4, key=modified_average))
+14
 
 ```
 
-You can also run it for `beam_width=1, 2, 4, 8, ..., 2^power`:
+We can also run it for `beam_width=1, 2, 4, 8, ..., 2^power`:
 
 ```pycon
 >>> from solvers import anytime_beam_search
->>> for moves in anytime_beam_search(board, power=5):
-...    print(f"Found solution of length {len(moves)}: {moves}")
-Found solution of length 10: [(3, 3), (1, 4), (1, 3), (1, 1), (3, 1), (4, 1), (1, 0), (2, 0), (3, 4), (3, 0)]
-Found solution of length 9: [(2, 0), (3, 0), (4, 1), (2, 2), (3, 4), (3, 3), (3, 3), (4, 1), (4, 4)]
-Found solution of length 8: [(2, 0), (3, 0), (3, 3), (1, 2), (4, 1), (3, 4), (4, 4), (4, 3)]
+>>> for moves in anytime_beam_search(board, power=6, key=None):
+...    print(f"Found solution of length {len(moves)}")
+Found solution of length 19
+Found solution of length 16
+Found solution of length 15
+Found solution of length 14
+
+```
+
+### Monte Carlo search
+
+**Monte Carlo tree search** also yields solutions as they are discovered.
+In the long run it produces a solution, but again we might run out of memory.
+
+```pycon
+>>> from solvers import monte_carlo_search
+>>> for moves in monte_carlo_search(board, seed=1, iterations=99, key=cleared_per_move):
+...    print(f"Found solution of length {len(moves)}")
+Found solution of length 24
+Found solution of length 23
+Found solution of length 22
+Found solution of length 21
+Found solution of length 20
+
+```
+
+Better keys help here too, because they help tie-beak between UCB scores and
+help guide the simulation (rollout) stage. Simulations use a weighted sampling
+of key values, where weights are given by `w_i = exp(-k * key(node))`.
+
+```pycon
+>>> for moves in monte_carlo_search(board, seed=1, iterations=99, key=modified_average):
+...    print(f"Found solution of length {len(moves)}")
+Found solution of length 17
+Found solution of length 16
+Found solution of length 15
+
 
 ```

--- a/board.py
+++ b/board.py
@@ -541,19 +541,37 @@ class Board:
         """An upper bound on the optimal solution (minimum moves needed).
 
         This heuristic counts the number of unique valid clicks, i.e., the
-        number of connected groups of the same color / integer. By starting
-        from the top of the board and never choosing a group that merges other
-        groups further down, we can realize this bound. In the example below,
-        this amounts to choosing 1, 2, 3 and then 4.
+        number of connected groups of the same color / integer. This seems
+        to be an upper bound on the optimal solution, but I have been unable
+        to prove it. If you can prove it, submit a PR and let me know :)
+
+        Below are two examples where it's not obvious how to attain the bound,
+        because we cannot simply start from the top. However, the bounds can
+        be attained here too.
 
         Examples
         --------
-        >>> board = Board([[1, 1, 2],
-        ...                [2, 2, 2],
-        ...                [3, 3, 4],
-        ...                [4, 4, 4]])
-        >>> board.upper_bound
+
+        The upper bound cannot be realized by an algorithm that starts at
+        the top group. Here is a counterexample:
+
+        >>> board = Board([[1, 1],
+        ...                [1, 3],
+        ...                [1, 1],
+        ...                [3, 3]])
+        >>> board.upper_bound  # Can be solved in 2 clicks
+        3
+
+        The upper bound cannot be realized by an algorithm that only makes
+        moves where the upper bound goes down by 1. Here is a counterexample:
+
+        >>> board = Board([[4, 4, 4],
+        ...                [4, 2, 1],
+        ...                [4, 4, 2]])
+        >>> board.upper_bound  # Can be solved in 3 clicks
         4
+        >>> print([child.upper_bound for _, child in board.children()])
+        [2, 4, 4, 4]
         """
         return len(self.clicks())
 

--- a/board.py
+++ b/board.py
@@ -112,24 +112,38 @@ Finally, all children (results of all valid clicks) can be retrieved:
     231
     <BLANKLINE>
 
-Lower and upper bounds on the number of clicks needed to solve. This board is
-constructed so that the upper bound can be achieved:
+We can use the properties `lower_bound` and `upper_bound` to get bounds on the
+solution length. The lower bound never overestimates the solution length.
+It's a consistent heuristic when used in A* search. The upper bound represents
+an upper bound on the optimal solution, but it's possible to find longer
+solution paths. This diagram explains the situation:
+
+        shortest solution path                   longest solution path
+        <------------------------------------------------------------>
+        ^
+        |
+        optimal solution
+
+<------------------------------------->
+lower bound                 upper bound
+
+
+Here is a board where the optimal solution equals the upper bound:
 
     >>> board = Board([[1, 1, 1],
-    ...               [2, 2, 2],
-    ...               [1, 1, 1],
-    ...               [2, 2, 2],
-    ...               [1, 1, 1],
-    ...               [2, 2, 2],
-    ...               [3, 1, 3],
-    ...               [1, 1, 1]])
+    ...                [2, 2, 2],
+    ...                [1, 1, 1],
+    ...                [2, 2, 2],
+    ...                [1, 1, 1],
+    ...                [2, 2, 2],
+    ...                [3, 1, 3],
+    ...                [1, 1, 1]])
     >>> board.lower_bound
     4
     >>> board.upper_bound
     9
 
-Lower and upper bounds on the number of clicks needed to solve. This board is
-constructed so that the upper bound can be achieved:
+Here is a board where the optimal solution equals the lower bound:
 
     >>> board = Board([[0, 0, 0, 3],
     ...                [0, 3, 3, 2],
@@ -139,7 +153,14 @@ constructed so that the upper bound can be achieved:
     >>> board.upper_bound
     6
 
+Here is a board where the optimal solution (which is 3) is between the bounds:
 
+    >>> board = Board([[1, 2],
+    ...                [2, 1]])
+    >>> board.lower_bound
+    2
+    >>> board.upper_bound
+    4
 """
 
 from typing import List, Tuple
@@ -395,8 +416,10 @@ class Board:
         (Board([[0, 2], [1, 2]]), 1)
         """
         outside = not (0 <= i < self.rows and 0 <= j < self.cols)
-        if outside or self.grid[i][j] == 0:
-            raise ValueError("Invalid click.")
+        if outside:
+            raise ValueError("Invalid click: {(i, j)} is outside.")
+        if self.grid[i][j] == 0:
+            raise ValueError("Invalid click: {(i, j)} is on value 0.")
 
         new_board, num_removed = self.copy()._apply_move(i, j)
         return (new_board, num_removed) if return_removed else new_board
@@ -474,7 +497,7 @@ class Board:
 
     @functools.cached_property
     def lower_bound(self):
-        """A lower bound on the number of clicks needed to solve.
+        """A lower bound on the optimal solution (minimum moves needed).
 
         The simplest lower bound is to count the unique number of non-zero
         integers. A better heuristic (this one) looks at each color in turn.
@@ -515,14 +538,13 @@ class Board:
 
     @property
     def upper_bound(self):
-        """An upper bound on the number of clicks needed to solve.
+        """An upper bound on the optimal solution (minimum moves needed).
 
         This heuristic counts the number of unique valid clicks, i.e., the
         number of connected groups of the same color / integer. By starting
         from the top of the board and never choosing a group that merges other
         groups further down, we can realize this bound. In the example below,
         this amounts to choosing 1, 2, 3 and then 4.
-
 
         Examples
         --------

--- a/report.py
+++ b/report.py
@@ -346,7 +346,7 @@ if __name__ == "__main__":
 
             # Start with a greedy search
             moves = greedy_search(board)
-            print("Initial bound by greedy: {len(moves)}")
+            print(f"Initial bound by greedy: {len(moves)}")
 
             print("Running beam search")
             power = 12

--- a/report.py
+++ b/report.py
@@ -344,8 +344,12 @@ if __name__ == "__main__":
             board = Board(instance.board.grid)
             print(f"Board number: {board_no} (best known: {instance.best}) \n{board}")
 
+            # Start with a greedy search
+            moves = greedy_search(board)
+            print("Initial bound by greedy: {len(moves)}")
+
             print("Running beam search")
-            power = 5
+            power = 12
             st = time.perf_counter()
             results = list(search_timer(anytime_beam_search, board, power=power))
             print(f"Ran in: {time.perf_counter() - st:.2f}")
@@ -355,9 +359,17 @@ if __name__ == "__main__":
             best_moves = results[-1][1]
 
             print("Running heuristic search")
-            iterations = 500
+            iterations = 100_000
             st = time.perf_counter()
-            results = list(search_timer(heuristic_search, board, iterations=iterations))
+            results = list(
+                search_timer(
+                    heuristic_search,
+                    board,
+                    iterations=iterations,
+                    verbose=False,
+                    moves=moves,
+                )
+            )
             print(f"Ran in: {time.perf_counter() - st:.2f}")
             times = [seconds for (seconds, num_moves) in results]
             num_moves = [len(moves) for (seconds, moves) in results]
@@ -367,10 +379,16 @@ if __name__ == "__main__":
             best_moves = min([best_moves, results[-1][1]], key=len)
 
             print("Running Monte Carlo search")
-            iterations = 100
+            iterations = 100_000
             st = time.perf_counter()
             results = list(
-                search_timer(monte_carlo_search, board, iterations=iterations)
+                search_timer(
+                    monte_carlo_search,
+                    board,
+                    iterations=iterations,
+                    verbosity=0,
+                    moves=moves,
+                )
             )
             print(f"Ran in: {time.perf_counter() - st:.2f}")
             times = [seconds for (seconds, num_moves) in results]
@@ -440,7 +458,7 @@ if __name__ == "__main__":
         plt.show()
 
     # Try best-first seach with various values of `power` on a board
-    if True:
+    if False:
         plt.figure(figsize=(6, 3))
         rng = random.Random(42)
 

--- a/report.py
+++ b/report.py
@@ -10,10 +10,11 @@ from solvers import (
     a_star_search,
     heuristic_search,
     monte_carlo_search,
-    best_first_search,
+    greedy_search,
     iterative_deepening_search,
     beam_search,
     anytime_beam_search,
+    middle_bound,
 )
 import statistics
 import matplotlib.pyplot as plt
@@ -22,6 +23,7 @@ from collections import deque
 from instances import NRK_boards
 import random
 import functools
+import math
 
 
 def yield_board_shapes():
@@ -137,23 +139,33 @@ def dfs_counter(board: Board, max_depth=1) -> int:
     return depth_counts
 
 
-def best_first_performance(board, simulations=100):
-    """Try best-first search with various powers on a board many times."""
+def randomized_greedy_performance(board, simulations=25):
+    """Try randomized greedy search on a board many times."""
+
+    def random_key(node, exponent=None):
+        """Random weighted sampling chooses element k with probability equal
+        to the weight w_k / sum_i^n w_i. This is equivalent to computing
+        Uniform(0, 1)**(1/w_i) for each i and choosing the maximal element.
+        See 'Weighted random sampling with a reservoir', Efraimidis et al."""
+        # Compute score
+        score = middle_bound(node)
+        if exponent is None:
+            return score
+
+        # Lower is better, so set w = exp(-score). Since we're maximizing and
+        # taking maximum is unaffected by monotonic transformations, we take
+        # logarithms: log[U(0, 1)**(1/w)] = 1/w * log(U) = exp(w) * log(U)
+        # Finally, we take minimum since lower is better on the output.
+        return -pow(exponent, score) * math.log(rng.random())
 
     # The lower the value of power, the more randomess
     # The higher the value of power, the more we focus on large groups of colors
-    for exponent in [1, 2, 5, 10, 25, None]:
-        if exponent is None:
-            # Pure best first search
-            moves = best_first_search(board, exponent=None, seed=None)
-            yield exponent, [len(moves)]
-            continue
-
+    for exponent in [1, 2, 5, 10, 25, 100, None]:
         results = []
         for simulation in range(simulations):
-            moves = best_first_search(board, exponent=exponent, seed=simulation)
+            key = functools.partial(random_key, exponent=exponent)
+            moves = greedy_search(board, key=key)
             results.append(len(moves))
-
         yield exponent, results
 
 
@@ -230,11 +242,21 @@ def benchmark(algorithm, *, simulations, **kwargs):
             board = LabelInvariantBoard(board.relabel().grid)
         start_time = time.perf_counter()
 
-        generator_or_list = algorithm(board, **kwargs)
+        # If "moves" is a keyword argument, provide an initial solution
+        if "moves" in algorithm.__kwdefaults__:
+            moves = greedy_search(board)
+            generator_or_list = algorithm(board, moves=moves, **kwargs)
+        else:
+            generator_or_list = algorithm(board, **kwargs)
+
+        # Extract the results
         if isinstance(generator_or_list, list):
             moves = generator_or_list
         else:
-            *_, moves = generator_or_list
+            try:
+                *_, moves = generator_or_list
+            except ValueError:  # Nothing came out from it :(
+                moves = moves
 
         times.append(time.perf_counter() - start_time)
         board.verify_solution(moves)
@@ -252,10 +274,10 @@ if __name__ == "__main__":
         benchmark = functools.partial(benchmark, simulations=10)
 
         # Parameters such that each solver takes ~15s to solve an instance
-        benchmark(best_first_search, exponent=None, seed=0)
-        benchmark(anytime_beam_search, power=9)
-        benchmark(heuristic_search, max_nodes=64_000, verbose=False)
-        benchmark(monte_carlo_search, iterations=650, seed=1)
+        benchmark(greedy_search)
+        benchmark(anytime_beam_search, power=5)
+        benchmark(heuristic_search, iterations=500, verbose=False)
+        benchmark(monte_carlo_search, iterations=50, seed=1)
 
     # Solve random boards to optimality and create a plot
     if False:
@@ -263,7 +285,7 @@ if __name__ == "__main__":
         plt.title("Solving random boards to optimality")
 
         # Set time limit and number of boards here
-        time_solver = functools.partial(time_solver, max_time=2, num_boards=5)
+        time_solver = functools.partial(time_solver, max_time=0.1, num_boards=5)
 
         solutions = list(time_solver(iterative_deepening_search))
         n = len(solutions)
@@ -299,7 +321,7 @@ if __name__ == "__main__":
     # Investigate the branching factor of a board instance
     if False:
         board = NRK_boards[26].board
-        for max_depth in range(1, 5):
+        for max_depth in range(1, 4):
             print()
             depth_counts = dfs_counter(board, max_depth=max_depth)
 
@@ -323,7 +345,7 @@ if __name__ == "__main__":
             print(f"Board number: {board_no} (best known: {instance.best}) \n{board}")
 
             print("Running beam search")
-            power = 16
+            power = 5
             st = time.perf_counter()
             results = list(search_timer(anytime_beam_search, board, power=power))
             print(f"Ran in: {time.perf_counter() - st:.2f}")
@@ -333,22 +355,22 @@ if __name__ == "__main__":
             best_moves = results[-1][1]
 
             print("Running heuristic search")
-            max_nodes = 6_000_000
+            iterations = 500
             st = time.perf_counter()
-            results = list(search_timer(heuristic_search, board, max_nodes=max_nodes))
+            results = list(search_timer(heuristic_search, board, iterations=iterations))
             print(f"Ran in: {time.perf_counter() - st:.2f}")
             times = [seconds for (seconds, num_moves) in results]
             num_moves = [len(moves) for (seconds, moves) in results]
             plt.semilogx(
-                times, num_moves, "-o", label=f"heuristic_search({max_nodes=:.1e})"
+                times, num_moves, "-o", label=f"heuristic_search({iterations=:.1e})"
             )
             best_moves = min([best_moves, results[-1][1]], key=len)
 
-            print("Running MCTS")
-            iterations = 300_000
+            print("Running Monte Carlo search")
+            iterations = 100
             st = time.perf_counter()
             results = list(
-                search_timer(monte_carlo_search, board, iterations=iterations, seed=42)
+                search_timer(monte_carlo_search, board, iterations=iterations)
             )
             print(f"Ran in: {time.perf_counter() - st:.2f}")
             times = [seconds for (seconds, num_moves) in results]
@@ -384,7 +406,7 @@ if __name__ == "__main__":
     if False:
         plt.figure(figsize=(6, 3))
         plt.title("Beam search on NRK instances")
-        MAX_POWER = 8
+        MAX_POWER = 5
 
         for board_no, instance in sorted(NRK_boards.items()):
             print(f"Beam search on board number {board_no}")
@@ -417,46 +439,18 @@ if __name__ == "__main__":
         plt.savefig("beam_search_NRK_instances.png", dpi=200)
         plt.show()
 
-    # Plot the best solution sequence - using many iterations
-    if False:
-        BOARD_NUMBER = 28
-        board = Board(NRK_boards[BOARD_NUMBER].board.grid)
-
-        *_, moves_bs = anytime_beam_search(board, power=15, verbose=True)
-
-        max_nodes = 300_000
-        *_, moves_h = heuristic_search(
-            board, max_nodes=max_nodes, verbose=True, shortest_path=len(moves_bs)
-        )
-
-        iterations = 500_000
-        *_, moves_mc = monte_carlo_search(
-            board,
-            iterations=iterations,
-            seed=42,
-            verbosity=1,
-            shortest_path=min(len(moves_bs), len(moves_h)),
-        )
-
-        moves = min([moves_mc, moves_h, moves_bs], key=len)
-        print(f"Best solution: {moves}")
-
-        fig, axes = plot_solution(board, moves)
-        plt.savefig(
-            f"best_solution_found_board_no_{BOARD_NUMBER}_manyiters.png", dpi=200
-        )
-        plt.show()
-
     # Try best-first seach with various values of `power` on a board
-    if False:
+    if True:
         plt.figure(figsize=(6, 3))
         rng = random.Random(42)
 
         board = NRK_boards[16].board
-        plt.title(f"Best-first search on a board with shape {(board.rows, board.cols)}")
+        plt.title(f"Greedy search on a board with shape {(board.rows, board.cols)}")
+
+        rng = random.Random(0)
 
         labels = []
-        sim_results = best_first_performance(board, simulations=100)
+        sim_results = randomized_greedy_performance(board, simulations=100)
         for i, (power, results) in enumerate(sim_results):
             x = [i + (rng.random() - 0.5) * 0.33 for _ in results]
             labels.append(str(power))
@@ -473,7 +467,7 @@ if __name__ == "__main__":
                     ecolor="black",
                 )
 
-        plt.xlabel("Power")
+        plt.xlabel("Exponent")
         plt.xticks(list(range(len(labels))), labels)
         plt.ylabel("Number of moves in solution")
         plt.grid(True, ls="--", zorder=0, alpha=0.33)

--- a/solvers.py
+++ b/solvers.py
@@ -321,7 +321,6 @@ class AStarNode:
     board: Board
     moves: tuple  # Using tuple instead of list since lists aren't hashable
 
-
     def f(self):
         if not self.moves:
             return 0
@@ -576,9 +575,6 @@ def heuristic_search(
         current = heappop(heap)
         current_g = len(current.moves)  # g(node) = number of moves
         popped_counter += 1
-
-        # if current_g + current.board.upper_bound < shortest_path:
-        #    print(f"{current_g=} + {current.board.upper_bound=} < {shortest_path=}")
 
         if popped_counter % max((max_nodes // 100), 1) == 0 and verbose:
             msg = f"""Nodes popped:{popped_counter}  Progress:{popped_counter/max_nodes:.1%}  Shortest path:{shortest_path}

--- a/solvers.py
+++ b/solvers.py
@@ -742,7 +742,7 @@ def monte_carlo_search(
         if verbosity >= v:
             print(*args, **kwargs)
 
-    def random_key(node, exponent=10.0):
+    def random_key(node, exponent=12.0):
         """Random weighted sampling chooses element k with probability equal
         to the weight w_k / sum_i^n w_i. This is equivalent to computing
         Uniform(0, 1)**(1/w_i) for each i and choosing the maximal element.
@@ -788,7 +788,7 @@ def monte_carlo_search(
             return
 
         # Simulate from leaf node of explored tree down to the end of the game
-        # The randomized moves might overestimate, so we run two simulations.
+        # The randomized moves might overestimate, so we can run two simulations.
         # simulation_moves = min(greedy_search(node.board, key=random_key),
         #                       greedy_search(node.board, key=key), key=len)
         simulation_moves = greedy_search(node.board, key=random_key)

--- a/solvers.py
+++ b/solvers.py
@@ -321,23 +321,20 @@ class AStarNode:
     board: Board
     moves: tuple  # Using tuple instead of list since lists aren't hashable
 
-    def g(self):
-        return len(self.moves)
 
-    def h(self):
-        return self.board.lower_bound
-
-    @functools.cached_property
     def f(self):
-        num_moves = len(self.moves)
+        if not self.moves:
+            return 0
         # Return (admissible_heuristic(), non_admissible(), non_admissible())
         # The overall result is still admissible, but the second and third
         # component of the tuple act as tie-breakers
-        cleared_per_move = self.board.cleared / num_moves
-        return (self.g() + self.h(), -cleared_per_move, -num_moves)
+        lower_bound = len(self.moves) + self.board.lower_bound
+        upper_bound = len(self.moves) + self.board.upper_bound
+        cleared_per_move = self.board.cleared / len(self.moves)
+        return (lower_bound, upper_bound, -cleared_per_move)
 
     def __lt__(self, other):
-        return self.f < other.f
+        return self.f() < other.f()
 
 
 def a_star_search(board: Board) -> list:

--- a/test_solvers.py
+++ b/test_solvers.py
@@ -183,7 +183,7 @@ class TestNonRegressionOnPerformance:
             assert board.verify_solution(moves)
             solution_lengths.append(len(moves))
 
-        assert statistics.mean(solution_lengths) <= 15.1
+        assert statistics.mean(solution_lengths) <= 14.9
 
     def test_performance_heuristic_search(self):
         solution_lengths = []
@@ -193,7 +193,7 @@ class TestNonRegressionOnPerformance:
             assert board.verify_solution(moves)
             solution_lengths.append(len(moves))
 
-        assert statistics.mean(solution_lengths) <= 16.1
+        assert statistics.mean(solution_lengths) <= 14.2
 
     def test_performance_monte_carlo_search(self):
         solution_lengths = []

--- a/test_solvers.py
+++ b/test_solvers.py
@@ -15,6 +15,7 @@ from solvers import (
     monte_carlo_search,
     iterative_deepening_search,
     anytime_beam_search,
+    greedy_search,
 )
 
 
@@ -111,13 +112,66 @@ class TestSolvers:
         assert board.verify_solution(moves_astar)
 
         # Solving the board with MCTS
-        for moves in monte_carlo_search(board, iterations=999999, seed=42):
+        for moves in monte_carlo_search(board, seed=42):
             assert board.verify_solution(moves)
 
             if len(moves_astar) == len(moves):
                 break
         else:
             assert False
+
+    def test_key_functions(self):
+        # Create a random board
+        board = Board.generate_random(shape=(9, 7), seed=0)
+
+        def node_to_scores(node):
+            # Priority 1: Compute a biased average of total moves => lower is better
+            alpha = 0.5
+            avg = (1 - alpha) * node.board.lower_bound + alpha * node.board.upper_bound
+            expected = len(node.moves) + avg
+
+            # Priority 2: Compute the range between low and high => lower is better
+            assert node.board.upper_bound >= node.board.lower_bound
+            range_ = abs(node.board.upper_bound - node.board.lower_bound) ** 0.5
+
+            # Priority 3: Cleared per move => higher is better
+            cleared_per_move = node.cleared / len(node.moves) if node.moves else 0
+            return (expected, range_, cleared_per_move)
+
+        def scalar_key(node):
+            (expected, range_, cleared_per_move) = node_to_scores(node)
+            return 1.0 * expected + 0.1 * range_ - 0.01 * cleared_per_move
+
+        # Call solvers with key function
+        moves = greedy_search(board, key=scalar_key)
+        *_, moves = anytime_beam_search(board, power=4, key=scalar_key)
+        assert board.verify_solution(moves)
+        *_, moves = monte_carlo_search(board, iterations=100, seed=0, key=scalar_key)
+        assert board.verify_solution(moves)
+        *_, moves = heuristic_search(board, iterations=100, key=scalar_key)
+        assert board.verify_solution(moves)
+
+        def tuple_key(node):
+            (expected, range_, cleared_per_move) = node_to_scores(node)
+            return (expected, range_, -cleared_per_move)
+
+        # Call solvers with key function
+        moves = greedy_search(board, key=tuple_key)
+        *_, moves = anytime_beam_search(board, power=4, key=tuple_key)
+        assert board.verify_solution(moves)
+        *_, moves = monte_carlo_search(board, iterations=100, seed=0, key=tuple_key)
+        assert board.verify_solution(moves)
+        *_, moves = heuristic_search(board, iterations=100, key=tuple_key)
+        assert board.verify_solution(moves)
+
+
+@pytest.mark.parametrize("seed", range(999))
+def test_that_astar_solutions_are_within_bounds(seed):
+    # Create a random board with a random shape
+    rng = random.Random(seed)
+    shape = rng.randint(2, 5), rng.randint(2, 5)
+    board = Board.generate_random(shape=shape, seed=seed)
+    assert board.lower_bound <= len(a_star_search(board)) <= board.upper_bound
 
 
 class TestNonRegressionOnPerformance:
@@ -135,13 +189,13 @@ class TestNonRegressionOnPerformance:
         solution_lengths = []
         for seed in range(10):
             board = Board.generate_random(shape=(9, 7), seed=seed)
-            *_, moves = heuristic_search(board, max_nodes=5000)
+            *_, moves = heuristic_search(board, iterations=5000)
             assert board.verify_solution(moves)
             solution_lengths.append(len(moves))
 
         assert statistics.mean(solution_lengths) <= 16.1
 
-    def test_performance_verify_solution(self):
+    def test_performance_monte_carlo_search(self):
         solution_lengths = []
         for seed in range(10):
             board = Board.generate_random(shape=(9, 7), seed=seed)
@@ -149,7 +203,7 @@ class TestNonRegressionOnPerformance:
             assert board.verify_solution(moves)
             solution_lengths.append(len(moves))
 
-        assert statistics.mean(solution_lengths) <= 15.8
+        assert statistics.mean(solution_lengths) <= 16.1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<img width="392" alt="image" src="https://github.com/user-attachments/assets/ce90b3a8-7361-4101-b372-463edb027329">

- Rewrote docs showcasing solver(key=) functionality
- Tune the default key on data. alpha=0.30 works well
- Rename best_first_search() to greedy_search()
- Add argument 'moves' to most solvers (initial upper bound)
- One common Node class (attrs: board, moves, cleared)
- Rewrite MCTS to work with arbitrary key
- Rewrite MCTS to use (cleared) as score, not (cleared/moves)
- Formulate BFS as a call to heuristic_search with a custom key function
- Formulate a_star_search as a call to heuristic_search with admissible key function
- Rename max_nodes to iterations in heuristic_search
